### PR TITLE
Fix filter values not returning to defaults on image load

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
         <div class="tool-group">
             <div id="correction" class="tool"><i class="fas fa-edit"></i>Correction</div>
             <div class="sub-tool">
-                <label>Exposure: <input id="exposure" type="range"></label>
-                <label>Contrast: <input id="contrast" type="range"></label>
+                <label>Exposure: <input id="exposure" data-filter="brightness" type="range" value="0"></label>
+                <label>Contrast: <input id="contrast" type="range" value="0"></label>
             </div>
         </div>
         <div class="tool-group">
@@ -31,21 +31,21 @@
         <div class="tool-group">
             <div id="blur_tool" class="tool"><i class="fas fa-quidditch"></i>Blur</div>
             <div class="sub-tool">
-                <label>Radius: <input id="blur_radius" type="range"></label>
-                <label>Strength: <input id="blur_strength" type="range"></label>
+                <label>Radius: <input id="blur_radius" type="range" value="0"></label>
+                <label>Strength: <input id="blur_strength" type="range" value="0"></label>
             </div>
         </div>
         <div class="tool-group">
             <div id="sharpen_tool" class="tool"><i class="fab fa-codepen"></i>Sharpen</div>
             <div class="sub-tool">
-                <label>Strength: <input id="sharpen_strength" type="range"></label>
+                <label>Strength: <input id="sharpen_strength" type="range" value="0"></label>
             </div>
         </div>
         <div class="tool-group">
             <div id="color_filter_tool" class="tool"><i class="fas fa-palette"></i>Color Filter</div>
             <div class="sub-tool">
                 <label>Color: <input id="color_picker" type="color" value="#fdffff"></label>
-                <label>Opacity: <input id="color_opacity" type="range"></label>
+                <label>Opacity: <input id="color_opacity" type="range" value="0"></label>
             </div>
         </div>
         <div id="clear_all" class="tool"><i class="fas fa-edit"></i>Clear All</div>

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,12 @@ loadImage.addEventListener('change', e => {
         canvas.height = image.naturalHeight;
         canvas.width = image.naturalWidth;
         canvasContext.drawImage(image, 0, 0);
+        Object.keys(filters).forEach(filter => {
+            const input = 
+                document.getElementById(filter) || 
+                document.querySelector(`[data-filter=${filter}`);
+            if (input) input.value = 0;
+        });
     }
 });
 


### PR DESCRIPTION
Fixes #7 

When the image is first loaded, no filters are applied, thus their initial value must be zero. The default value when not set on the HTML element was 50, so those were adjusted as well.

I saw that you labeled the canvas brightness filter for exposure. To get around the mismatches without modifying your code, I added a data attribute where you can specify the filter name.

I have quite a bit of experience at my day job with the Canvas API if you need any help.